### PR TITLE
fix: Add not_authorized to ResultEncoder

### DIFF
--- a/lib/srh/http/result_encoder.ex
+++ b/lib/srh/http/result_encoder.ex
@@ -1,5 +1,10 @@
 defmodule Srh.Http.ResultEncoder do
 
+  # Authentication errors don't get encoded, we need to skip over those
+  def encode_response({:not_authorized, message}) do
+    {:not_authorized, message}
+  end
+
   # Errors don't get encoded, we need to skip over those
   def encode_response({:redis_error, error_result_map}) do
     {:redis_error, error_result_map}


### PR DESCRIPTION
This fixes an exception being thrown by requests containing invalid auth.

Before, `@upstash/redis` would throw the following error when using invalid auth:
`Error: SyntaxError: Unexpected end of JSON input`
SRH logs also showed this error:
```
﻿00:33:22.502 [error] #PID<0.1202.0> running Srh.Http.BaseRouter (connection #PID<0.1201.0>, stream id 1) terminated
﻿Server: redis.uuid.rocks:80 (http)
﻿Request: POST /
﻿** (exit) an exception was raised:
﻿** (FunctionClauseError) no function clause matching in Srh.Http.ResultEncoder.encode_response/1
﻿(srh 0.1.0) lib/srh/http/result_encoder.ex:4: Srh.Http.ResultEncoder.encode_response({:not_authorized, "Invalid token"})
﻿(srh 0.1.0) lib/srh/http/base_router.ex:36: Srh.Http.BaseRouter.do_command_request/2
﻿(srh 0.1.0) lib/plug/router.ex:246: anonymous fn/4 in Srh.Http.BaseRouter.dispatch/2
﻿(telemetry 1.1.0) /app/deps/telemetry/src/telemetry.erl:320: :telemetry.span/3
﻿(srh 0.1.0) lib/plug/router.ex:242: Srh.Http.BaseRouter.dispatch/2
﻿(srh 0.1.0) lib/srh/http/base_router.ex:1: Srh.Http.BaseRouter.plug_builder_call/2
﻿(plug_cowboy 2.5.2) lib/plug/cowboy/handler.ex:12: Plug.Cowboy.Handler.init/2
﻿(cowboy 2.9.0) /app/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
```

After this PR, `@upstash/redis` throws the following:
`SyntaxError: Unexpected token 'I', "Invalid token" is not valid JSON`

This is a much more helpful client error, and cleans up the SRH logs (which no longer show anything with invalid auth errors.)