### PR TITLE
Standardise errors

### DIFF
--- a/lib/srh/http/base_router.ex
+++ b/lib/srh/http/base_router.ex
@@ -5,6 +5,7 @@ defmodule Srh.Http.BaseRouter do
   alias Srh.Http.ResultEncoder
 
   plug(:match)
+  plug(Srh.Http.ContentTypeCheckPlug)
   plug(Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Jason)
   plug(:dispatch)
 

--- a/lib/srh/http/base_router.ex
+++ b/lib/srh/http/base_router.ex
@@ -97,7 +97,7 @@ defmodule Srh.Http.BaseRouter do
           {500, {:error, message}}
 
         _ ->
-          {500, {:error, "An error occurred internally"}}
+          {500, {:error, "SRH: An error occurred internally"}}
       end
 
     conn

--- a/lib/srh/http/base_router.ex
+++ b/lib/srh/http/base_router.ex
@@ -25,7 +25,7 @@ defmodule Srh.Http.BaseRouter do
   end
 
   match _ do
-    send_resp(conn, 404, "Endpoint not found")
+    handle_response({:not_found, "SRH: Endpoint not found. SRH might not support this feature yet."}, conn)
   end
 
   defp do_command_request(conn, success_lambda) do
@@ -104,13 +104,9 @@ defmodule Srh.Http.BaseRouter do
     |> send_resp(code, create_response_body(resp_data))
   end
 
-  defp create_response_body({:data, data}) do
-    # Directly encode
-    Jason.encode!(data)
-  end
+  # :data just directly encodes
+  defp create_response_body({:data, data}), do: Jason.encode!(data)
 
-  defp create_response_body({:error, error}) do
-    # Wrap in error
-    Jason.encode!(%{error: error})
-  end
+  # :error wraps the message in an error object
+  defp create_response_body({:error, error}), do: Jason.encode!(%{error: error})
 end

--- a/lib/srh/http/content_type_check_plug.ex
+++ b/lib/srh/http/content_type_check_plug.ex
@@ -31,7 +31,7 @@ defmodule Srh.Http.ContentTypeCheckPlug do
         conn
 
       # Either missing, or a type that we don't support
-      other ->
+      _ ->
         # Return a custom error, ensuring the same format as the other errors
         conn
         |> put_resp_content_type("application/json")

--- a/lib/srh/http/content_type_check_plug.ex
+++ b/lib/srh/http/content_type_check_plug.ex
@@ -1,0 +1,42 @@
+defmodule Srh.Http.ContentTypeCheckPlug do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    # Only parse for POST, PUT, PATCH, and DELETE requests, which is what Plug.Parsers does
+    case conn.method do
+      "POST" ->
+        check_content_type(conn)
+
+      "PUT" ->
+        check_content_type(conn)
+
+      "PATCH" ->
+        check_content_type(conn)
+
+      "DELETE" ->
+        check_content_type(conn)
+
+      # All other methods can proceed
+      _ ->
+        conn
+    end
+  end
+
+  defp check_content_type(conn) do
+    case get_req_header(conn, "content-type") do
+      ["application/json"] ->
+        # Proceed, this is the valid content type for SRH
+        conn
+
+      # Either missing, or a type that we don't support
+      other ->
+        # Return a custom error, ensuring the same format as the other errors
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(400, Jason.encode!(%{error: "Invalid content type. Expected application/json."}))
+        |> halt()
+    end
+  end
+end


### PR DESCRIPTION
Cases to test:
- [x]  Missing bearer header, eventually hits a match for :malformed_data, so :not_found is never actually triggered (can remove if so) _It was unused, but is now being used for actual 404 errors such as below_
- [x] Handle additional 404s as JSON errors too, as could be due to future Upstash features using a new endpoint (such as when multi-exec was added)
- [x] Not including Content-Type json will cause a 500 to be thrown without an error message at all _SRH code isn't even hit, this is happening by a missing Plug Parser_