### PR TITLE
16 improve test ci to actually build srh and run that image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,12 +61,12 @@ jobs:
       # it can directly address Redis. We still need to expose SRH's port to the host machine, however, so that
       # we can run tests against it.
       - name: Run SRH container
-        run: > 
-          docker run -it -d -p 8080:80 
-            --network ${{ job.container.network }} 
-            -e SRH_MODE=env 
-            -e SRH_TOKEN=${{ env.SRH_TOKEN }} 
-            -e SRH_CONNECTION_STRING="redis://redis:6379" 
+        run: \
+          docker run -it -d -p 8080:80 \ 
+            --network ${{ job.container.network }} \ 
+            -e SRH_MODE=env \
+            -e SRH_TOKEN=${{ env.SRH_TOKEN }} \ 
+            -e SRH_CONNECTION_STRING="redis://redis:6379" \ 
             hiett/serverless-redis-http:latest
 
       # The following tests fail because of bugs with Upstash's implementation of Redis, NOT because of our library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
   container-job:
     runs-on: ubuntu-latest
     container: denoland/deno
+    needs: build
     services:
       redis:
         image: redis/redis-stack-server:6.2.6-v6 # 6.2 is the Upstash compatible Redis version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,8 @@ jobs:
 
       - name: Load SRH image
         run: |
-          docker load --input /tmp/serverless-redis-http.tar
-          docker image ls -a
+          /usr/bin/docker load --input /tmp/serverless-redis-http.tar
+          /usr/bin/docker image ls -a
 
       - name: Run SRH container
         uses: addnab/docker-run-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,12 +62,7 @@ jobs:
       # we can run tests against it.
       - name: Run SRH container
         run: |
-          docker run -it -d -p 8080:80 \ 
-            --network ${{ job.container.network }} \ 
-            -e SRH_MODE=env \
-            -e SRH_TOKEN=${{ env.SRH_TOKEN }} \ 
-            -e SRH_CONNECTION_STRING="redis://redis:6379" \ 
-            hiett/serverless-redis-http:latest
+          docker run -it -d -p 8080:80 --network ${{ job.container.network }} -e SRH_MODE=env -e SRH_TOKEN=${{ env.SRH_TOKEN }} -e SRH_CONNECTION_STRING="redis://redis:6379" hiett/serverless-redis-http:latest
 
       # The following tests fail because of bugs with Upstash's implementation of Redis, NOT because of our library
       # So we remove them from the test suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       # it can directly address Redis. We still need to expose SRH's port to the host machine, however, so that
       # we can run tests against it.
       - name: Run SRH container
-        run: \
+        run: |
           docker run -it -d -p 8080:80 \ 
             --network ${{ job.container.network }} \ 
             -e SRH_MODE=env \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,11 @@ name: Test @upstash/redis compatability
 on:
   workflow_dispatch:
   push:
-#    paths:
-#      - 'lib/**'
+    paths:
+      - 'lib/**'
+      - 'Dockerfile'
+      - 'mix.exs'
+      - 'mix.lock'
   schedule:
     - cron: '0 12 * * *'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,17 +31,22 @@ jobs:
 
   container-job:
     runs-on: ubuntu-latest
-    container: denoland/deno
     needs: build
     services:
       redis:
         image: redis/redis-stack-server:6.2.6-v6 # 6.2 is the Upstash compatible Redis version
+        ports:
+          - 6379:6379
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           repository: upstash/upstash-redis
+
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
 
       - name: Download SRH artifact
         uses: actions/download-artifact@v3
@@ -51,14 +56,14 @@ jobs:
 
       - name: Load SRH image
         run: |
-          /usr/bin/docker load --input /tmp/serverless-redis-http.tar
-          /usr/bin/docker image ls -a
+          docker load --input /tmp/serverless-redis-http.tar
+          docker image ls -a
 
       - name: Run SRH container
         uses: addnab/docker-run-action@v3
         with:
           image: hiett/serverless-redis-http:latest
-          options: -it -d -e SRH_MODE=env -e SRH_TOKEN=${{ env.SRH_TOKEN }} -e SRH_CONNECTION_STRING="redis://redis:6379"
+          options: -it -d -p 8080:80 -e SRH_MODE=env -e SRH_TOKEN=${{ env.SRH_TOKEN }} -e SRH_CONNECTION_STRING="redis://redis:6379"
 
       # The following tests fail because of bugs with Upstash's implementation of Redis, NOT because of our library
       # So we remove them from the test suite
@@ -71,5 +76,5 @@ jobs:
       - name: Run @upstash/redis Test Suite
         run: deno test -A ./pkg
         env:
-          UPSTASH_REDIS_REST_URL: http://srh:80
+          UPSTASH_REDIS_REST_URL: http://localhost:8080
           UPSTASH_REDIS_REST_TOKEN: ${{ env.SRH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,6 @@ jobs:
     services:
       redis:
         image: redis/redis-stack-server:6.2.6-v6 # 6.2 is the Upstash compatible Redis version
-        ports:
-          - 6379:6379
 
     steps:
       - name: Checkout code
@@ -57,13 +55,19 @@ jobs:
       - name: Load SRH image
         run: |
           docker load --input /tmp/serverless-redis-http.tar
-          docker image ls -a
+          docker image ls -a | grep serverless-redis-http
 
+      # Placed inside the same docker network as the service container with job.container.network, at which point
+      # it can directly address Redis. We still need to expose SRH's port to the host machine, however, so that
+      # we can run tests against it.
       - name: Run SRH container
-        uses: addnab/docker-run-action@v3
-        with:
-          image: hiett/serverless-redis-http:latest
-          options: -it -d -p 8080:80 -e SRH_MODE=env -e SRH_TOKEN=${{ env.SRH_TOKEN }} -e SRH_CONNECTION_STRING="redis://redis:6379"
+        run: > 
+          docker run -it -d -p 8080:80 
+            --network ${{ job.container.network }} 
+            -e SRH_MODE=env 
+            -e SRH_TOKEN=${{ env.SRH_TOKEN }} 
+            -e SRH_CONNECTION_STRING="redis://redis:6379" 
+            hiett/serverless-redis-http:latest
 
       # The following tests fail because of bugs with Upstash's implementation of Redis, NOT because of our library
       # So we remove them from the test suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: Test @upstash/redis compatability
 on:
   workflow_dispatch:
   push:
-    paths:
-      - 'lib/**'
+#    paths:
+#      - 'lib/**'
   schedule:
     - cron: '0 12 * * *'
 
@@ -11,24 +11,53 @@ env:
   SRH_TOKEN: example_token
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SRH code
+        uses: actions/checkout@v3
+
+      - name: Build Dockerfile
+        run: docker build -t hiett/serverless-redis-http:latest .
+
+      - name: Export to TAR
+        run: docker save hiett/serverless-redis-http:latest -o /tmp/serverless-redis-http.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: serverless-redis-http
+          path: /tmp/serverless-redis-http.tar
+
   container-job:
     runs-on: ubuntu-latest
     container: denoland/deno
     services:
       redis:
         image: redis/redis-stack-server:6.2.6-v6 # 6.2 is the Upstash compatible Redis version
-      srh:
-        image: hiett/serverless-redis-http:latest
-        env:
-          SRH_MODE: env
-          SRH_TOKEN: ${{ env.SRH_TOKEN }}
-          SRH_CONNECTION_STRING: redis://redis:6379
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           repository: upstash/upstash-redis
+
+      - name: Download SRH artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: serverless-redis-http
+          path: /tmp
+
+      - name: Load SRH image
+        run: |
+          docker load --input /tmp/serverless-redis-http.tar
+          docker image ls -a
+
+      - name: Run SRH container
+        uses: addnab/docker-run-action@v3
+        with:
+          image: hiett/serverless-redis-http:latest
+          options: -it -d -e SRH_MODE=env -e SRH_TOKEN=${{ env.SRH_TOKEN }} -e SRH_CONNECTION_STRING="redis://redis:6379"
 
       # The following tests fail because of bugs with Upstash's implementation of Redis, NOT because of our library
       # So we remove them from the test suite


### PR DESCRIPTION
Rather than pulling the latest image, checks out the code, builds an image and then tests that