### PR TITLE
Ensure pool is destroyed when failing to connect to Redis

### DIFF
--- a/lib/srh/http/base_router.ex
+++ b/lib/srh/http/base_router.ex
@@ -26,7 +26,10 @@ defmodule Srh.Http.BaseRouter do
   end
 
   match _ do
-    handle_response({:not_found, "SRH: Endpoint not found. SRH might not support this feature yet."}, conn)
+    handle_response(
+      {:not_found, "SRH: Endpoint not found. SRH might not support this feature yet."},
+      conn
+    )
   end
 
   defp do_command_request(conn, success_lambda) do

--- a/lib/srh/http/command_handler.ex
+++ b/lib/srh/http/command_handler.ex
@@ -131,7 +131,6 @@ defmodule Srh.Http.CommandHandler do
             result
 
           {:error, %{reason: :closed} = error} ->
-            IO.puts("Transaction error: #{inspect(error)}")
             # Ensure that this pool is killed, but still pass the error up the chain for the response
             Client.destroy_workers(client_pid)
             decode_error(error, srh_id)
@@ -175,8 +174,6 @@ defmodule Srh.Http.CommandHandler do
        when is_number(max_connections) do
     case GenRegistry.lookup_or_start(Client, srh_id, [max_connections, connection_info]) do
       {:ok, pid} ->
-        IO.puts("SRH: Found client #{inspect(pid)}")
-
         # Run the command
         case Client.find_worker(pid)
              |> ClientWorker.redis_command(command_array) do

--- a/lib/srh/http/command_handler.ex
+++ b/lib/srh/http/command_handler.ex
@@ -130,6 +130,12 @@ defmodule Srh.Http.CommandHandler do
             # Fire back the result here, because the initial Multi was successful
             result
 
+          {:error, %{reason: :closed} = error} ->
+            IO.puts("Transaction error: #{inspect(error)}")
+            # Ensure that this pool is killed, but still pass the error up the chain for the response
+            Client.destroy_workers(client_pid)
+            decode_error(error, srh_id)
+
           {:error, error} ->
             decode_error(error, srh_id)
         end

--- a/lib/srh/http/content_type_check_plug.ex
+++ b/lib/srh/http/content_type_check_plug.ex
@@ -35,7 +35,10 @@ defmodule Srh.Http.ContentTypeCheckPlug do
         # Return a custom error, ensuring the same format as the other errors
         conn
         |> put_resp_content_type("application/json")
-        |> send_resp(400, Jason.encode!(%{error: "Invalid content type. Expected application/json."}))
+        |> send_resp(
+          400,
+          Jason.encode!(%{error: "Invalid content type. Expected application/json."})
+        )
         |> halt()
     end
   end

--- a/lib/srh/redis/client.ex
+++ b/lib/srh/redis/client.ex
@@ -35,6 +35,10 @@ defmodule Srh.Redis.Client do
     GenServer.cast(client, {:return_worker, pid})
   end
 
+  def destroy_workers(client) do
+    GenServer.cast(client, {:destroy_workers})
+  end
+
   def handle_call({:find_worker}, _from, %{registry_pid: registry_pid} = state)
       when is_pid(registry_pid) do
     {:ok, worker} = ClientRegistry.find_worker(registry_pid)
@@ -59,13 +63,17 @@ defmodule Srh.Redis.Client do
     {:noreply, state}
   end
 
+  def handle_cast({:destroy_workers}, state) do
+    ClientRegistry.destroy_workers(state.registry_pid)
+    {:stop, :normal, state}
+  end
+
   def handle_cast(_msg, state) do
     {:noreply, state}
   end
 
   def handle_info(:idle_death, state) do
     ClientRegistry.destroy_workers(state.registry_pid)
-
     {:stop, :normal, state}
   end
 

--- a/lib/srh/redis/client.ex
+++ b/lib/srh/redis/client.ex
@@ -3,7 +3,7 @@ defmodule Srh.Redis.Client do
   alias Srh.Redis.ClientRegistry
   alias Srh.Redis.ClientWorker
 
-  @idle_death_time 1000 * 15
+  @idle_death_time 1000 * 60 * 15 # 15 minutes
 
   def start_link(max_connections, connection_info) do
     GenServer.start_link(__MODULE__, {max_connections, connection_info}, [])

--- a/lib/srh/redis/client_registry.ex
+++ b/lib/srh/redis/client_registry.ex
@@ -33,8 +33,6 @@ defmodule Srh.Redis.ClientRegistry do
   end
 
   def destroy_workers(registry) do
-    # TODO: remove before shipping
-    IO.puts("DEBUG: Destroying workers")
     GenServer.cast(registry, {:destroy_workers})
   end
 

--- a/lib/srh/redis/client_registry.ex
+++ b/lib/srh/redis/client_registry.ex
@@ -33,6 +33,8 @@ defmodule Srh.Redis.ClientRegistry do
   end
 
   def destroy_workers(registry) do
+    # TODO: remove before shipping
+    IO.puts("DEBUG: Destroying workers")
     GenServer.cast(registry, {:destroy_workers})
   end
 

--- a/lib/srh/redis/client_worker.ex
+++ b/lib/srh/redis/client_worker.ex
@@ -18,7 +18,6 @@ defmodule Srh.Redis.ClientWorker do
   end
 
   def redis_command(worker, command_array) do
-    IO.puts("redis_command (for pid #{inspect(worker)}): #{inspect(command_array)}")
     GenServer.call(worker, {:redis_command, command_array})
   end
 

--- a/lib/srh/redis/client_worker.ex
+++ b/lib/srh/redis/client_worker.ex
@@ -18,6 +18,7 @@ defmodule Srh.Redis.ClientWorker do
   end
 
   def redis_command(worker, command_array) do
+    IO.puts("redis_command (for pid #{inspect(worker)}): #{inspect(command_array)}")
     GenServer.call(worker, {:redis_command, command_array})
   end
 


### PR DESCRIPTION
See issue for initial reasoning

Ensure that PIDs for the parent client is rotated on every command when the previous one had failed
- [x] Works in individual commands
- [x] Works in pipelines
- [x] Works in multi exec

Also adds in SSL support, enabled with rediss:// urls automatically