### PR TITLE
Load port from env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     needs: build
     services:
       redis:
-        image: redis/redis-stack-server:6.2.6-v6 # 6.2 is the Upstash compatible Redis version
+        image: redis/redis-stack-server:7.2.0-v7
 
     steps:
       - name: Checkout code
@@ -79,7 +79,7 @@ jobs:
         run: bun install
 
       - name: Run @upstash/redis Test Suite
-        run: bun test pkg
+        run: bun run test
         env:
           UPSTASH_REDIS_REST_URL: http://localhost:8080
           UPSTASH_REDIS_REST_TOKEN: ${{ env.SRH_TOKEN }}

--- a/lib/srh.ex
+++ b/lib/srh.ex
@@ -1,10 +1,12 @@
 defmodule Srh do
   use Application
 
-  @port Application.fetch_env!(:srh, :port)
+  @default_port Application.fetch_env!(:srh, :port)
 
   def start(_type, _args) do
-    IO.puts("Using port #{@port}")
+    {port, ""} = Integer.parse(System.get_env("SRH_PORT", Integer.to_string(@default_port))) # Remains @default_port for backwards compatibility
+
+    IO.puts("Using port #{port}")
 
     children = [
       Srh.Auth.TokenResolver,
@@ -14,7 +16,7 @@ defmodule Srh do
         scheme: :http,
         plug: Srh.Http.BaseRouter,
         options: [
-          port: @port
+          port: port
         ]
       }
     ]


### PR DESCRIPTION
By default in production, the service uses port 80. This should be configurable.
Using the environment variable `SRH_PORT`, the port specified should be used. In case that is absent, and for backwards compatability, it should use the port 80.