### PR TITLE
fix: Fix runtime config exception

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
+# syntax=docker/dockerfile:1
+
+###
 FROM elixir:1.13.4-alpine AS builder
+
+#
+ARG MIX_ENV=prod
+ENV MIX_ENV=${MIX_ENV}
+
+ARG PORT
 
 WORKDIR /app
 
@@ -13,14 +22,17 @@ RUN mix deps.get
 COPY lib/ ./lib/
 COPY config/ ./config/
 
-ENV MIX_ENV=prod
 RUN mix release
 
+###
 FROM elixir:1.13.4-alpine
+
+#
+ARG MIX_ENV=prod
+ENV MIX_ENV=${MIX_ENV}
 
 WORKDIR /app
 
-COPY --from=builder /app/_build/prod/rel/prod/ ./_build/prod/rel/prod/
+COPY --from=builder /app/_build/${MIX_ENV}/rel/prod/ ./_build/${MIX_ENV}/rel/prod/
 
-ENV MIX_ENV=prod
-CMD ["_build/prod/rel/prod/bin/prod", "start"]
+CMD ["sh", "-c", "_build/${MIX_ENV}/rel/prod/bin/prod start"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,21 @@
+###
+services:
+  # docker buildx bake
+  srh:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      platforms:
+        - linux/amd64
+        - linux/arm64
+      args:
+        - MIX_ENV=${MIX_ENV:-runtime}
+        - PORT=${PORT:-80}
+    ports:
+      - '8079:${PORT:-80}'
+    image: local/serverless-redis-http
+    environment:
+      SRH_PORT: ${PORT:-80}
+      SRH_MODE: env
+      SRH_TOKEN: example_token
+      SRH_CONNECTION_STRING: 'redis://redis:6379'

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -3,4 +3,4 @@ import Config
 config :srh,
   mode: System.get_env("TOKEN_RESOLUTION_MODE") || "file",
   file_path: System.get_env("TOKEN_RESOLUTION_FILE_PATH") || "srh-config/tokens.json",
-  port: Integer.parse(System.get_env("PORT") || "8080")
+  port: String.to_integer(System.get_env("PORT", "8080"))


### PR DESCRIPTION
Thanks for your excellent work, without which it wouldn’t have been possible to run the Vercel AI chatbot locally. I also updated the Docker files to support building for different MIX_ENV environments (e.g., dev, test, prod). 

ChatGPT helped with the fix, as I had no prior knowledge of Elixir, so I'm not 100% sure it is correct but it seems to work for me.


