### PR TITLE
Fix CI by upgrading `actions/download-artifact` to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: docker save hiett/serverless-redis-http:latest -o /tmp/serverless-redis-http.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: serverless-redis-http
           path: /tmp/serverless-redis-http.tar
@@ -50,7 +50,7 @@ jobs:
           bun-version: latest
 
       - name: Download SRH artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: serverless-redis-http
           path: /tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - 'mix.lock'
   schedule:
     - cron: '0 12 * * *'
+  pull_request:
 
 env:
   SRH_TOKEN: example_token


### PR DESCRIPTION
the 'test @upstash/redis compatibility' job was consistently failing because of this outdated artifact step i.e.
https://github.com/hiett/serverless-redis-http/actions/runs/18312732316

this gets it through step 1, but the actual suite still seems to be failing; maybe just a configuration issue in my fork? I couldn't figure it out quickly:
https://github.com/jamiew/serverless-redis-http/actions/runs/18317489371/job/52161675040

I also tried using `act` to test GHAs locally but of course it said the old one was fine and the new one is fine too
